### PR TITLE
Revert which wiki-page-creation-action repo we're using (from mine back to main)

### DIFF
--- a/.github/workflows/master-merge.yml
+++ b/.github/workflows/master-merge.yml
@@ -25,7 +25,7 @@ jobs:
 
     # from: https://github.com/marketplace/actions/wiki-page-creator-action
     - name: Upload READMEs to Wiki
-      uses: devlinjunker/wiki-page-creator-action@patch-1
+      uses: docker://decathlon/wiki-page-creator-action:latest
       env:
         ACTION_MAIL: devlin.junker@gmail.com
         ACTION_NAME: devlinjunker


### PR DESCRIPTION
# Description
Reset Github Action so that wiki-page-creation-action is using main repo (Decathalon) after testing my patch to looping over all md files

# Related
https://github.com/Decathlon/wiki-page-creator-action/pull/16

# Visual
N/A

# TODO
 - [x] PR Body
 ~~- [ ] Updated READMEs~~
